### PR TITLE
Feat/add type safety to dashboard

### DIFF
--- a/src/app/dashboard/_components/DashboardClient.tsx
+++ b/src/app/dashboard/_components/DashboardClient.tsx
@@ -13,13 +13,29 @@ import HeartIcon from '@/components/icons/ecommerce/HeartIcon';
 import ShippingIcon from '@/components/icons/ecommerce/ShippingIcon';
 import AddressCardIcon from '@/components/icons/ecommerce/AddressCardIcon';
 
+export interface DashboardUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+}
+
+interface DashboardPageData {
+  orders?: any[];
+  user?: DashboardUser;
+  wishlistItems?: any[];
+}
+
 interface DashboardClientProps {
-  user: any;
-  pageData?: {
-    orders?: any[];
-    user?: any;
-    wishlistItems?: any[];
-  };
+  user: DashboardUser;
+  pageData?: DashboardPageData;
+}
+
+interface MenuItems {
+  id: string;
+  label: string;
+  icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+  Component: React.FC<{ user: DashboardUser; pageData?: DashboardPageData }>;
 }
 
 const SIDEBAR_STATE_KEY = 'dashboard-sidebar-collapsed';
@@ -47,36 +63,36 @@ export default function DashboardPage({
     setIsSidebarCollapsed((prevState) => !prevState);
   };
 
-  const menuItems = [
+  const menuItems: MenuItems[] = [
     {
       id: 'home',
       label: 'Account Home',
       icon: HomeIcon,
-      Component: () => <DashboardAccountHome user={user} />,
+      Component: DashboardAccountHome,
     },
     {
       id: 'history',
       label: 'Order History',
       icon: ShippingIcon,
-      Component: () => <DashboardOrderHistory />,
+      Component: DashboardOrderHistory,
     },
     {
       id: 'information',
       label: 'Account Information',
       icon: AddressCardIcon,
-      Component: () => <DashboardAccountInformation user={user} />,
+      Component: DashboardAccountInformation,
     },
     {
       id: 'wishlist',
       label: 'My Wishlist',
       icon: HeartIcon,
-      Component: () => <DashboardWishlist user={user} />,
+      Component: DashboardWishlist,
     },
     {
       id: 'cart',
       label: 'My Cart',
       icon: CartIcon,
-      Component: () => <DashboardCart />,
+      Component: DashboardCart,
     },
   ];
   const activeMenuItem = menuItems.find((item) => item.id === activeTab);
@@ -90,9 +106,9 @@ export default function DashboardPage({
         toggleSidebar={handleToggleSidebar}
       />
 
-      <section className='flex-1'>
+      <section className='flex-1 overflow-y-auto'>
         {activeMenuItem ? (
-          <activeMenuItem.Component />
+          <activeMenuItem.Component user={user} />
         ) : (
           <div className='pt-10 w-[95%] m-auto space-y-8'>
             <h1 className='text-4xl font-bold'>

--- a/src/app/dashboard/_components/layout/DashboardSidebar.tsx
+++ b/src/app/dashboard/_components/layout/DashboardSidebar.tsx
@@ -29,7 +29,7 @@ export default function DashboardSidebar({
   toggleSidebar,
 }: DashboardSidebarProps) {
   const mainContainerClassName = clsx(
-    'border-r border-[#6c6c6c] h-full transition-all duration-300 ease-in-out overflow-hidden',
+    'border-r border-[#6c6c6c] h-full transition-all duration-300 ease-in-out overflow-hidden flex-shrink-0',
     isCollapsed ? 'min-w-20 w-20' : 'min-w-72 w-72'
   );
 
@@ -71,7 +71,7 @@ export default function DashboardSidebar({
                   <span
                     className={clsx(
                       'transition-opacity duration-300 ease-in-out whitespace-nowrap',
-                      isCollapsed ? 'opacity-0' : 'opacity-100'
+                      isCollapsed ? 'sr-only' : 'opacity-100'
                     )}
                   >
                     {item.label}
@@ -98,7 +98,7 @@ export default function DashboardSidebar({
           <span
             className={clsx(
               'transition-opacity duration-300 ease-in-out whitespace-nowrap',
-              isCollapsed ? 'opacity-0 w-0' : 'opacity-100'
+              isCollapsed ? 'sr-only' : 'opacity-100'
             )}
           >
             Collapse Sidebar

--- a/src/app/dashboard/_components/tabs/AccountHomeTab.tsx
+++ b/src/app/dashboard/_components/tabs/AccountHomeTab.tsx
@@ -4,14 +4,10 @@ import MapPinIcon from '@/components/icons/ecommerce/MapPinIcon';
 import ShippingIcon from '@/components/icons/ecommerce/ShippingIcon';
 import clsx from 'clsx';
 import Link from 'next/link';
+import { DashboardUser } from '../DashboardClient';
 
 interface DashboardAccountHomeProps {
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    image: string | null;
-  };
+  user: DashboardUser;
 }
 
 const listItems = [

--- a/src/app/dashboard/_components/tabs/AccountInformationTab.tsx
+++ b/src/app/dashboard/_components/tabs/AccountInformationTab.tsx
@@ -1,10 +1,7 @@
+import { DashboardUser } from '../DashboardClient';
+
 interface DashboardAccountInformationProps {
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    image: string | null;
-  };
+  user: DashboardUser;
 }
 
 export default function DashboardAccountInformation({

--- a/src/app/dashboard/_components/tabs/WishlistTab.tsx
+++ b/src/app/dashboard/_components/tabs/WishlistTab.tsx
@@ -5,14 +5,10 @@ import {
   selectWishlistTotalItems,
   useWishlistStore,
 } from '@/store/wishlistStore';
+import { DashboardUser } from '../DashboardClient';
 
 interface DashboardWishlistProps {
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    image: string | null;
-  };
+  user: DashboardUser;
 }
 
 export default function DashboardWishlist({ user }: DashboardWishlistProps) {

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -15,9 +15,9 @@ export default async function RootLayout({
   }
 
   return (
-    <div className='min-h-screen flex flex-col justify-between'>
+    <div className='h-screen flex flex-col'>
       <HeaderLayout variant='simple' />
-      <main className='flex-1 flex'>{children}</main>
+      <main className='flex-1 flex overflow-hidden'>{children}</main>
     </div>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,8 @@ import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/prisma';
 import DashboardClient from './_components/DashboardClient';
 import { authOptions } from '../api/auth/[...nextauth]/route';
+import { redirect } from 'next/navigation';
+import toast from 'react-hot-toast';
 
 export default async function DashboardPage({
   searchParams,
@@ -14,8 +16,13 @@ export default async function DashboardPage({
 
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { name: true, email: true, image: true },
+    select: { id: true, name: true, email: true, image: true },
   });
 
-  return <DashboardClient user={user} />;
+  if (!user) {
+    toast.error('Error: User Not Found');
+    redirect('/login');
+  }
+
+  return <DashboardClient user={user!} />;
 }


### PR DESCRIPTION
- create Type-Safe Interfaces for Dashboard
- reuse User Interface inside Dashboard Tabs
- fix overflow styling for Dashboard, resulting in Dashboard only ever being 100svh (including Header)
- add fail-safe reroute for case when prisma.findUnique outputs null